### PR TITLE
Connections & Cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,18 +3,16 @@ name: Build & Deploy
 on:
   push:
     branches: [typescript, development]
+  pull_request:
+    branches: [development]
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push:
+  test:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
     steps:
       - uses: actions/checkout@v4
 
@@ -26,6 +24,17 @@ jobs:
           DISCORD_OWNER_ID: ${{ secrets.DISCORD_OWNER_ID }}
           TEST_DISCORD_WEBHOOK_URL: ${{ secrets.TEST_DISCORD_WEBHOOK_URL }}
           DEBUG_DISCORD_WEBHOOK_URL: ${{ secrets.DEBUG_DISCORD_WEBHOOK_URL }}
+
+  build-and-push:
+    needs: test
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Resolve image metadata
         id: tag

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { JobScheduler } from './services/application/JobScheduler';
 import { initAsync } from './utils/registries/InitRegistry';
 import { syncRoutines } from './utils/routines/Sync';
 import { validateSchemaAsync } from './utils/database/GenerateSchema';
+import TestMode from './utils/application/TestMode';
 
 getConfig();
 
@@ -36,16 +37,19 @@ discordClient.once('ready', async () => {
     if (success) {
       if (!getConfigValue(EnvConfigEnum.DEBUG_MODE)) {
         try {
-          await syncRoutines();
-          await validateSchemaAsync();
+          // Pool now actually pools → these two DB-touching tasks run in parallel
+          await Promise.all([syncRoutines(), validateSchemaAsync()]);
         } catch (err) {
           Logger.logError('Routine sync failed, shutting down', err as Error, { sendToDiscord: true });
           process.exit(1);
         }
       }
       await initAsync();
-      await loadCommands(discordClient);
-      await loadEvents(discordClient);
+      // Command + event collectors are independent — load concurrently
+      await Promise.all([
+        loadCommands(discordClient),
+        loadEvents(discordClient),
+      ]);
       const port = Number(getConfigValue(EnvConfigEnum.DISGAMES_API_PORT) || 3600);
       startHttpServer(port);
 
@@ -57,4 +61,9 @@ discordClient.once('ready', async () => {
   });
 });
 
-discordClient.login(getConfigValue(EnvConfigEnum.TOKEN));
+// During test runs the DiscordClient is constructed only because something in the
+// import graph touches `discordClient` (e.g. DiscordService). We must NOT log in or
+// the bot's `ready` handler will race with tests, fire initAsync a second time, and
+// try to bind the HTTP port that's already serving the test process.
+if (!TestMode.isEnabled())
+    discordClient.login(getConfigValue(EnvConfigEnum.TOKEN));

--- a/src/repositories/BaseRepository.ts
+++ b/src/repositories/BaseRepository.ts
@@ -2,7 +2,7 @@ import { TableEnum, StoredProcedureEnum, ExceptionEnum } from "../interfaces/enu
 import { MetadataKeyEnum } from "../interfaces/enums/application/MetadataKeyEnum";
 import { getEnumProperty } from "../utils/helpers/EnumMetadata";
 import { FunctionEnum } from "../interfaces/enums/database/FunctionEnum";
-import { getTableName, runQueryAsync } from "./util/ConnectionHandler";
+import { getTableName, runExecuteAsync, runQueryAsync } from "./util/ConnectionHandler";
 import { DatabaseHelper } from "../utils/database/DatabaseHelper";
 import { CacheManager } from "./util/CacheManager";
 import { isValidEnumValue } from "../utils/helpers/Enum";
@@ -185,7 +185,7 @@ class BaseRepository<Model extends BaseEntity, SaveModel extends BaseEntity, Fie
     }
 
     // Non-cached query path
-    const results = await runQueryAsync(this.query, this.params);
+    const results = await runExecuteAsync(this.query, this.params);
     this.params = [];
     this.hasLimit1 = false;
 
@@ -197,7 +197,7 @@ class BaseRepository<Model extends BaseEntity, SaveModel extends BaseEntity, Fie
 
   private async executeQueryAndCache(queryHash: string): Promise<Model[]> {
     try {
-      const results = await runQueryAsync(this.query, this.params);
+      const results = await runExecuteAsync(this.query, this.params);
 
       if (!results || results.length === 0) {
         return [];
@@ -232,8 +232,10 @@ class BaseRepository<Model extends BaseEntity, SaveModel extends BaseEntity, Fie
     const serializedEntity = DatabaseHelper.processEntityForDatabase(entity, this.fieldEnum, this.fieldTypeFunction);
 
     if (serializedEntity.Id) {
-      // UPDATE - invalidate cache for this ID and all query cache
-      this.cacheManager.invalidateCache(serializedEntity.Id);
+      // Capture cached entry before invalidating query caches so we can merge
+      const cachedBefore = this.cacheManager.getCacheEntry(serializedEntity.Id);
+
+      // Query-by-hash cache must always be dropped; the row cache is updated below
       this.cacheManager.invalidateAllQueryCache();
 
       if (isValidEnumValue(this.fieldEnum, 'UpdatedAt'))
@@ -242,7 +244,7 @@ class BaseRepository<Model extends BaseEntity, SaveModel extends BaseEntity, Fie
       // UPDATE - only include fields that are explicitly set (not undefined)
       const fieldsToUpdate: string[] = [];
       const valuesToUpdate: any[] = [];
-      
+
       for (const [key, value] of Object.entries(serializedEntity)) {
         if (key !== 'Id' && value !== undefined) {
           fieldsToUpdate.push(key);
@@ -252,6 +254,7 @@ class BaseRepository<Model extends BaseEntity, SaveModel extends BaseEntity, Fie
 
       if (fieldsToUpdate.length === 0) {
         // No fields to update, just return the existing record
+        this.cacheManager.invalidateCache(serializedEntity.Id);
         const result = await this.Select().Where({ Id: serializedEntity.Id }).Execute();
         if (result.length === 0)
           ErrorHelper.throw(ExceptionEnum.RECORD_NOT_FOUND);
@@ -262,15 +265,32 @@ class BaseRepository<Model extends BaseEntity, SaveModel extends BaseEntity, Fie
       const query = `UPDATE ${this.table} SET ${setClause} WHERE Id = ?`;
       const params = [...valuesToUpdate, serializedEntity.Id];
 
-      // Run the update
-      await runQueryAsync(query, params);
+      // Run the update (single statement → execute() for prepared-statement caching)
+      await runExecuteAsync(query, params);
 
+      // Hot path: cached entry exists → merge known new values, skip the SELECT round-trip.
+      // Merge uses the caller-supplied deserialized `entity` (not `serializedEntity`) so
+      // MultiLingualString / JSON fields stay as objects, matching the cache shape.
+      if (cachedBefore) {
+        const mergedFields: Partial<Model> = {};
+        for (const [key, value] of Object.entries(entity)) {
+          if (value !== undefined)
+            (mergedFields as any)[key] = value;
+        }
+        if (isValidEnumValue(this.fieldEnum, 'UpdatedAt'))
+          (mergedFields as any).UpdatedAt = serializedEntity.UpdatedAt;
+        const merged = { ...cachedBefore, ...mergedFields } as Model;
+        this.cacheManager.setCacheEntry(serializedEntity.Id, merged);
+        return merged;
+      }
+
+      // Cold-cache fallback: read the canonical row back
+      this.cacheManager.invalidateCache(serializedEntity.Id);
       const result = await this.Select().Where({ Id: serializedEntity.Id }).Execute();
       if (result?.length === 0)
         ErrorHelper.throw(ExceptionEnum.RECORD_NOT_FOUND);
 
       const savedRecord = result?.[0] as Model;
-      // Update cache with fresh data
       this.cacheManager.setCacheEntry(serializedEntity.Id, savedRecord);
       return savedRecord;
     } else {
@@ -317,7 +337,7 @@ class BaseRepository<Model extends BaseEntity, SaveModel extends BaseEntity, Fie
 
     const query = `DELETE FROM ${this.table} WHERE Id = ?`;
     const params = [id];
-    await runQueryAsync(query, params);
+    await runExecuteAsync(query, params);
   }
 
   public async getExternalIdsAsync(): Promise<string[]> {
@@ -330,7 +350,7 @@ class BaseRepository<Model extends BaseEntity, SaveModel extends BaseEntity, Fie
       return [];
 
     const fieldName = String(externalIdField);
-    const results = await runQueryAsync(`SELECT ${fieldName} FROM ${this.table}`, []);
+    const results = await runExecuteAsync(`SELECT ${fieldName} FROM ${this.table}`, []);
 
     if (!results || results.length === 0) {
       this.cacheManager.setExternalIdCache([]);
@@ -363,7 +383,7 @@ export class RepositoryUtils {
   public static async CallStoredProcedureGeneric(procedure: StoredProcedureEnum, params: any[] = []): Promise<any[]> {
     const procedureName = procedure.toString();
     const query = `CALL ${procedureName}(${params.map(() => '?').join(', ')})`;
-    const results = await runQueryAsync(query, params);
+    const results = await runExecuteAsync(query, params);
 
     if (!results || !results[0])
       return [];
@@ -378,7 +398,7 @@ export class RepositoryUtils {
     const functionName = fn.toString();
     const placeholders = params.map(() => '?').join(', ');
     const query = `SELECT ${functionName}(${placeholders}) AS Result`;
-    const results = await runQueryAsync(query, params);
+    const results = await runExecuteAsync(query, params);
 
     if (!results || results.length === 0)
       return undefined;

--- a/src/repositories/util/ConnectionHandler.ts
+++ b/src/repositories/util/ConnectionHandler.ts
@@ -1,5 +1,6 @@
 import mysql from 'mysql2/promise';
 import dotenv from 'dotenv';
+import { AsyncLocalStorage } from 'async_hooks';
 import { TableEnum } from '../../interfaces/enums/database/TableEnum';
 import { URL } from 'url';
 import Logger from '../../utils/application/Logger';
@@ -12,9 +13,21 @@ import { WebhookType } from '../../interfaces/application';
 dotenv.config();
 
 let pool: mysql.Pool | null = null;
-let connection: mysql.PoolConnection | null = null;
 let table_enums: Array<{ Id: number, TableName: string }> = [];
-let inTransaction = false;
+
+export type TransactionHandle = {
+    connection: mysql.PoolConnection;
+};
+
+const transactionStorage = new AsyncLocalStorage<TransactionHandle>();
+
+function ambientTx(): TransactionHandle | undefined {
+    return transactionStorage.getStore();
+}
+
+export async function runInTransactionAsync<T>(tx: TransactionHandle, fn: () => Promise<T>): Promise<T> {
+    return transactionStorage.run(tx, fn);
+}
 
 function createPoolFromConfig(url: URL, dbName: string): mysql.Pool {
     return mysql.createPool({
@@ -53,26 +66,10 @@ function isRecoverableConnectionError(err: unknown): boolean {
     return false;
 }
 
-async function releaseHeldConnectionAsync(): Promise<void> {
-    if (!connection)
-        return;
-    const c = connection;
-    connection = null;
-    try {
-        c.destroy();
-    } catch {
-        try {
-            c.release();
-        } catch {
-        }
-    }
-}
-
 async function loadTableEnumsAsync(): Promise<void> {
-    if (!connection)
+    if (!pool)
         ErrorHelper.throw(ExceptionEnum.DATABASE_CONNECTION_FAILED);
-    const query = 'SELECT * FROM table_enums';
-    const [rows] = await connection.query(query);
+    const [rows] = await pool.query('SELECT * FROM table_enums');
     table_enums = rows as Array<{ Id: number, TableName: string }>;
 }
 
@@ -80,7 +77,6 @@ async function rebuildPoolAsync(): Promise<void> {
     const dbUrl = getConfigValue(EnvConfigEnum.DATABASE_URL) as string;
     if (!dbUrl)
         ErrorHelper.throwWithParameters(ExceptionEnum.ENV_VARIABLE_NOT_SET, { environmentVariable: 'DATABASE_URL' });
-    await releaseHeldConnectionAsync();
     if (pool) {
         try {
             await pool.end();
@@ -91,36 +87,13 @@ async function rebuildPoolAsync(): Promise<void> {
     const url = new URL(dbUrl);
     const dbName = url.pathname.replace(/^\//, '');
     pool = createPoolFromConfig(url, dbName);
-    connection = await pool.getConnection();
     await loadTableEnumsAsync();
 }
 
-async function reconnectAfterConnectionLossAsync(): Promise<void> {
-    await releaseHeldConnectionAsync();
-    if (!pool) {
-        await rebuildPoolAsync();
-        return;
-    }
-    try {
-        connection = await pool.getConnection();
-        await loadTableEnumsAsync();
-    } catch (err) {
-        Logger.logError('Failed to get database connection from pool after loss, rebuilding pool', err as Error, { sendToDiscord: true });
-        await rebuildPoolAsync();
-    }
-}
-
-async function ensureConnectionAsync(): Promise<void> {
-    if (connection)
-        return;
+function ensurePool(): mysql.Pool {
     if (!pool)
         ErrorHelper.throw(ExceptionEnum.DATABASE_CONNECTION_FAILED);
-    try {
-        connection = await pool.getConnection();
-    } catch (err) {
-        Logger.logError('Failed to acquire database connection', err as Error, { sendToDiscord: true });
-        await rebuildPoolAsync();
-    }
+    return pool;
 }
 
 //#region Connection Functions
@@ -137,7 +110,6 @@ export async function createConnectionAsync(): Promise<boolean> {
 
         pool = createPoolFromConfig(url, dbName);
 
-        connection = await pool.getConnection();
         await loadTableEnumsAsync();
         return true;
     } catch (err) {
@@ -147,9 +119,6 @@ export async function createConnectionAsync(): Promise<boolean> {
 }
 
 export async function closeConnectionAsync(): Promise<void> {
-    inTransaction = false;
-    await releaseHeldConnectionAsync();
-
     if (pool) {
         await pool.end();
         pool = null;
@@ -157,18 +126,21 @@ export async function closeConnectionAsync(): Promise<void> {
 }
 
 export async function validateConnectionAsync(): Promise<boolean> {
-    await ensureConnectionAsync();
-    if (!connection)
-        ErrorHelper.throw(ExceptionEnum.DATABASE_CONNECTION_FAILED);
+    const activePool = ensurePool();
+    let conn: mysql.PoolConnection | null = null;
     try {
-        await connection.ping();
+        conn = await activePool.getConnection();
+        await conn.ping();
         return true;
     } catch (err) {
         if (!isRecoverableConnectionError(err))
             ErrorHelper.wrap(err, ExceptionEnum.DATABASE_CONNECTION_FAILED);
-        Logger.logError('Database ping failed, reconnecting', err as Error);
-        await reconnectAfterConnectionLossAsync();
+        Logger.logError('Database ping failed, rebuilding pool', err as Error);
+        await rebuildPoolAsync();
         return true;
+    } finally {
+        if (conn)
+            conn.release();
     }
 }
 
@@ -176,29 +148,32 @@ export async function validateConnectionAsync(): Promise<boolean> {
 
 //#region Query Functions
 
-export async function runQueryAsync(query: string, params?: any[]): Promise<any[] | undefined> {
-    await ensureConnectionAsync();
-    if (!connection)
-        ErrorHelper.throw(ExceptionEnum.DATABASE_CONNECTION_FAILED);
+type Runner = (sql: string, params?: any[]) => Promise<[any, any]>;
 
-    const execute = async () => {
-        Logger.logDebug(params ? `Running query: ${query} with params ${params}` : `Running query: ${query}`);
-        const [rows] = await connection!.query(query, params);
-        return rows as any[];
-    };
+async function runWithRetry(
+    runner: (executor: Runner) => Promise<any[]>,
+    tx?: TransactionHandle,
+): Promise<any[] | undefined> {
+    const activePool = ensurePool();
+    const activeTx = tx ?? ambientTx();
+    const executor: Runner = activeTx
+        ? (sql, params) => activeTx.connection.query(sql, params) as Promise<[any, any]>
+        : (sql, params) => activePool.query(sql, params) as Promise<[any, any]>;
 
     try {
-        return await execute();
+        return await runner(executor);
     } catch (err) {
-        if (!inTransaction && isRecoverableConnectionError(err)) {
-            Logger.logError('Database connection lost, reconnecting', err as Error, {
+        if (!activeTx && isRecoverableConnectionError(err)) {
+            Logger.logError('Database connection lost, rebuilding pool', err as Error, {
                 webhookType: WebhookType.DEBUG,
                 sendToDiscord: true
             });
-
-            await reconnectAfterConnectionLossAsync();
             try {
-                return await execute();
+                await rebuildPoolAsync();
+                const retryPool = ensurePool();
+                const retryExecutor: Runner = (sql, params) =>
+                    retryPool.query(sql, params) as Promise<[any, any]>;
+                return await runner(retryExecutor);
             } catch (retryErr) {
                 Logger.logError(`Error while running database query`, retryErr as Error, { sendToDiscord: true });
                 ErrorHelper.wrap(retryErr, ExceptionEnum.DATABASE_CONNECTION_FAILED);
@@ -209,55 +184,100 @@ export async function runQueryAsync(query: string, params?: any[]): Promise<any[
     }
 }
 
+export async function runQueryAsync(query: string, params?: any[], tx?: TransactionHandle): Promise<any[] | undefined> {
+    return runWithRetry(async (executor) => {
+        if (Logger.isDebugEnabled())
+            Logger.logDebug(() => params ? `Running query: ${query} with params ${params}` : `Running query: ${query}`);
+        const [rows] = await executor(query, params);
+        return rows as any[];
+    }, tx);
+}
+
+// MySQL's prepared-statement protocol (used by .execute()) rejects parameterized
+// LIMIT/OFFSET on versions older than 8.0.23. mysql2's text protocol (.query()) handles
+// them universally, so we route those queries there automatically.
+function requiresTextProtocol(sql: string): boolean {
+    return /\s(LIMIT|OFFSET)\s*\?/i.test(sql);
+}
+
+export async function runExecuteAsync(query: string, params?: any[], tx?: TransactionHandle): Promise<any[] | undefined> {
+    if (requiresTextProtocol(query))
+        return runQueryAsync(query, params, tx);
+
+    const activePool = ensurePool();
+    const activeTx = tx ?? ambientTx();
+    const executor: Runner = activeTx
+        ? (sql, p) => activeTx.connection.execute(sql, p) as Promise<[any, any]>
+        : (sql, p) => activePool.execute(sql, p) as Promise<[any, any]>;
+
+    try {
+        if (Logger.isDebugEnabled())
+            Logger.logDebug(() => params ? `Running execute: ${query} with params ${params}` : `Running execute: ${query}`);
+        const [rows] = await executor(query, params);
+        return rows as any[];
+    } catch (err) {
+        if (!activeTx && isRecoverableConnectionError(err)) {
+            Logger.logError('Database connection lost during execute, rebuilding pool', err as Error, {
+                webhookType: WebhookType.DEBUG,
+                sendToDiscord: true
+            });
+            try {
+                await rebuildPoolAsync();
+                const retryPool = ensurePool();
+                const [rows] = await retryPool.execute(query, params);
+                return rows as any[];
+            } catch (retryErr) {
+                Logger.logError(`Error while running database execute`, retryErr as Error, { sendToDiscord: true });
+                ErrorHelper.wrap(retryErr, ExceptionEnum.DATABASE_CONNECTION_FAILED);
+            }
+        }
+        Logger.logError(`Error while running database execute`, err as Error, { sendToDiscord: true });
+        ErrorHelper.wrap(err, ExceptionEnum.DATABASE_CONNECTION_FAILED);
+    }
+}
+
 //#region Transaction Functions
 
-export async function startTransactionAsync(): Promise<void> {
-    await ensureConnectionAsync();
-    if (!connection)
-        ErrorHelper.throw(ExceptionEnum.DATABASE_CONNECTION_FAILED);
+export async function startTransactionAsync(): Promise<TransactionHandle> {
+    const activePool = ensurePool();
+    let conn: mysql.PoolConnection;
     try {
-        await connection.beginTransaction();
+        conn = await activePool.getConnection();
     } catch (err) {
         if (!isRecoverableConnectionError(err))
             ErrorHelper.wrap(err, ExceptionEnum.DATABASE_CONNECTION_FAILED);
-        Logger.logError('Database connection lost at transaction start, reconnecting', err as Error);
-        await reconnectAfterConnectionLossAsync();
-        if (!connection)
-            ErrorHelper.throw(ExceptionEnum.DATABASE_CONNECTION_FAILED);
-        try {
-            await connection.beginTransaction();
-        } catch (retryErr) {
-            ErrorHelper.wrap(retryErr, ExceptionEnum.DATABASE_CONNECTION_FAILED);
-        }
+        Logger.logError('Database connection lost at transaction start, rebuilding pool', err as Error);
+        await rebuildPoolAsync();
+        conn = await ensurePool().getConnection();
     }
-    inTransaction = true;
+
+    try {
+        await conn.beginTransaction();
+    } catch (err) {
+        conn.release();
+        ErrorHelper.wrap(err, ExceptionEnum.DATABASE_CONNECTION_FAILED);
+    }
+
+    return { connection: conn };
 }
 
-export async function rollbackTransactionAsync(): Promise<void> {
-    if (!connection) {
-        inTransaction = false;
-        ErrorHelper.throw(ExceptionEnum.DATABASE_CONNECTION_FAILED);
-    }
+export async function rollbackTransactionAsync(tx: TransactionHandle): Promise<void> {
     try {
-        await connection.rollback();
+        await tx.connection.rollback();
     } catch (err) {
         ErrorHelper.wrap(err, ExceptionEnum.DATABASE_CONNECTION_FAILED);
     } finally {
-        inTransaction = false;
+        tx.connection.release();
     }
 }
 
-export async function commitTransactionAsync(): Promise<void> {
-    if (!connection) {
-        inTransaction = false;
-        ErrorHelper.throw(ExceptionEnum.DATABASE_CONNECTION_FAILED);
-    }
+export async function commitTransactionAsync(tx: TransactionHandle): Promise<void> {
     try {
-        await connection.commit();
+        await tx.connection.commit();
     } catch (err) {
         ErrorHelper.wrap(err, ExceptionEnum.DATABASE_CONNECTION_FAILED);
     } finally {
-        inTransaction = false;
+        tx.connection.release();
     }
 }
 
@@ -284,6 +304,14 @@ export function getTableName(tableEnumValue: TableEnum): string {
             ErrorHelper.throwWithParameters(ExceptionEnum.TABLE_ENUM_NOT_FOUND, { tableEnumValue: tableEnumValue.toString() });
     }
     return enumValue;
+}
+
+//#endregion
+
+//#region Test Helpers (internal)
+
+export function _getPoolForTests(): mysql.Pool | null {
+    return pool;
 }
 
 //#endregion

--- a/src/repositories/util/ConnectionHandler.ts
+++ b/src/repositories/util/ConnectionHandler.ts
@@ -148,92 +148,72 @@ export async function validateConnectionAsync(): Promise<boolean> {
 
 //#region Query Functions
 
+type RunMode = 'query' | 'execute';
 type Runner = (sql: string, params?: any[]) => Promise<[any, any]>;
 
+function executorFor(mode: RunMode, pool: mysql.Pool, tx?: TransactionHandle): Runner {
+    if (tx)
+        return mode === 'execute'
+            ? (sql, p) => tx.connection.execute(sql, p) as Promise<[any, any]>
+            : (sql, p) => tx.connection.query(sql, p) as Promise<[any, any]>;
+    return mode === 'execute'
+        ? (sql, p) => pool.execute(sql, p) as Promise<[any, any]>
+        : (sql, p) => pool.query(sql, p) as Promise<[any, any]>;
+}
+
 async function runWithRetry(
-    runner: (executor: Runner) => Promise<any[]>,
+    mode: RunMode,
+    sql: string,
+    params?: any[],
     tx?: TransactionHandle,
 ): Promise<any[] | undefined> {
-    const activePool = ensurePool();
     const activeTx = tx ?? ambientTx();
-    const executor: Runner = activeTx
-        ? (sql, params) => activeTx.connection.query(sql, params) as Promise<[any, any]>
-        : (sql, params) => activePool.query(sql, params) as Promise<[any, any]>;
+    const label = mode === 'execute' ? 'execute' : 'query';
+
+    Logger.logDebug(() => params ? `Running ${label}: ${sql} with params ${params}` : `Running ${label}: ${sql}`);
+
+    const runOnce = async (pool: mysql.Pool): Promise<any[]> => {
+        const exec = executorFor(mode, pool, activeTx);
+        const [rows] = await exec(sql, params);
+        return rows as any[];
+    };
 
     try {
-        return await runner(executor);
+        return await runOnce(ensurePool());
     } catch (err) {
         if (!activeTx && isRecoverableConnectionError(err)) {
-            Logger.logError('Database connection lost, rebuilding pool', err as Error, {
+            Logger.logError(`Database connection lost during ${label}, rebuilding pool`, err as Error, {
                 webhookType: WebhookType.DEBUG,
-                sendToDiscord: true
+                sendToDiscord: true,
             });
             try {
                 await rebuildPoolAsync();
-                const retryPool = ensurePool();
-                const retryExecutor: Runner = (sql, params) =>
-                    retryPool.query(sql, params) as Promise<[any, any]>;
-                return await runner(retryExecutor);
+                return await runOnce(ensurePool());
             } catch (retryErr) {
-                Logger.logError(`Error while running database query`, retryErr as Error, { sendToDiscord: true });
+                Logger.logError(`Error while running database ${label}`, retryErr as Error, { sendToDiscord: true });
                 ErrorHelper.wrap(retryErr, ExceptionEnum.DATABASE_CONNECTION_FAILED);
             }
         }
-        Logger.logError(`Error while running database query`, err as Error, { sendToDiscord: true });
+        Logger.logError(`Error while running database ${label}`, err as Error, { sendToDiscord: true });
         ErrorHelper.wrap(err, ExceptionEnum.DATABASE_CONNECTION_FAILED);
     }
 }
 
-export async function runQueryAsync(query: string, params?: any[], tx?: TransactionHandle): Promise<any[] | undefined> {
-    return runWithRetry(async (executor) => {
-        if (Logger.isDebugEnabled())
-            Logger.logDebug(() => params ? `Running query: ${query} with params ${params}` : `Running query: ${query}`);
-        const [rows] = await executor(query, params);
-        return rows as any[];
-    }, tx);
+function requiresTextProtocol(sql: string): boolean {
+    // MySQL's prepared-statement protocol (used by .execute()) rejects parameterized
+    // LIMIT/OFFSET on versions older than 8.0.23. mysql2's text protocol (.query())
+    // handles them universally, so route those queries there automatically.
+    return /\s(LIMIT|OFFSET)\s*\?/i.test(sql);
 }
 
-// MySQL's prepared-statement protocol (used by .execute()) rejects parameterized
-// LIMIT/OFFSET on versions older than 8.0.23. mysql2's text protocol (.query()) handles
-// them universally, so we route those queries there automatically.
-function requiresTextProtocol(sql: string): boolean {
-    return /\s(LIMIT|OFFSET)\s*\?/i.test(sql);
+export async function runQueryAsync(query: string, params?: any[], tx?: TransactionHandle): Promise<any[] | undefined> {
+    return runWithRetry('query', query, params, tx);
 }
 
 export async function runExecuteAsync(query: string, params?: any[], tx?: TransactionHandle): Promise<any[] | undefined> {
     if (requiresTextProtocol(query))
-        return runQueryAsync(query, params, tx);
-
-    const activePool = ensurePool();
-    const activeTx = tx ?? ambientTx();
-    const executor: Runner = activeTx
-        ? (sql, p) => activeTx.connection.execute(sql, p) as Promise<[any, any]>
-        : (sql, p) => activePool.execute(sql, p) as Promise<[any, any]>;
-
-    try {
-        if (Logger.isDebugEnabled())
-            Logger.logDebug(() => params ? `Running execute: ${query} with params ${params}` : `Running execute: ${query}`);
-        const [rows] = await executor(query, params);
-        return rows as any[];
-    } catch (err) {
-        if (!activeTx && isRecoverableConnectionError(err)) {
-            Logger.logError('Database connection lost during execute, rebuilding pool', err as Error, {
-                webhookType: WebhookType.DEBUG,
-                sendToDiscord: true
-            });
-            try {
-                await rebuildPoolAsync();
-                const retryPool = ensurePool();
-                const [rows] = await retryPool.execute(query, params);
-                return rows as any[];
-            } catch (retryErr) {
-                Logger.logError(`Error while running database execute`, retryErr as Error, { sendToDiscord: true });
-                ErrorHelper.wrap(retryErr, ExceptionEnum.DATABASE_CONNECTION_FAILED);
-            }
-        }
-        Logger.logError(`Error while running database execute`, err as Error, { sendToDiscord: true });
-        ErrorHelper.wrap(err, ExceptionEnum.DATABASE_CONNECTION_FAILED);
-    }
+        return runWithRetry('query', query, params, tx);
+    return runWithRetry('execute', query, params, tx);
 }
 
 //#region Transaction Functions
@@ -247,18 +227,22 @@ export async function startTransactionAsync(): Promise<TransactionHandle> {
         if (!isRecoverableConnectionError(err))
             ErrorHelper.wrap(err, ExceptionEnum.DATABASE_CONNECTION_FAILED);
         Logger.logError('Database connection lost at transaction start, rebuilding pool', err as Error);
-        await rebuildPoolAsync();
-        conn = await ensurePool().getConnection();
+        try {
+            await rebuildPoolAsync();
+            conn = await ensurePool().getConnection();
+        } catch (retryErr) {
+            ErrorHelper.wrap(retryErr, ExceptionEnum.DATABASE_CONNECTION_FAILED);
+        }
     }
 
     try {
-        await conn.beginTransaction();
+        await conn!.beginTransaction();
     } catch (err) {
-        conn.release();
+        conn!.release();
         ErrorHelper.wrap(err, ExceptionEnum.DATABASE_CONNECTION_FAILED);
     }
 
-    return { connection: conn };
+    return { connection: conn! };
 }
 
 export async function rollbackTransactionAsync(tx: TransactionHandle): Promise<void> {
@@ -308,10 +292,3 @@ export function getTableName(tableEnumValue: TableEnum): string {
 
 //#endregion
 
-//#region Test Helpers (internal)
-
-export function _getPoolForTests(): mysql.Pool | null {
-    return pool;
-}
-
-//#endregion

--- a/src/services/application/MediaService.ts
+++ b/src/services/application/MediaService.ts
@@ -8,6 +8,7 @@ import Logger from "../../utils/application/Logger";
 class MediaService {
     private readonly imagesPath: string;
     private readonly notFoundImage: Media;
+    private readonly bufferCache: Map<string, Buffer> = new Map();
 
     constructor() {
         this.imagesPath = path.join(process.cwd(), 'images');
@@ -18,6 +19,39 @@ class MediaService {
         };
     }
 
+    public async initAsync(): Promise<void> {
+        const preloadPaths: string[] = [this.notFoundImage.url];
+
+        const baseNames: Array<'welcome' | 'profile' | 'aboutme' | 'settings'> =
+            ['welcome', 'profile', 'aboutme', 'settings'];
+        for (const name of baseNames)
+            preloadPaths.push(path.join(this.imagesPath, `${name}.${MediaType.PNG}`));
+
+        const gamesDir = path.join(this.imagesPath, 'games');
+        try {
+            const entries = await fs.promises.readdir(gamesDir);
+            for (const file of entries) {
+                if (file.endsWith(`.${MediaType.PNG}`))
+                    preloadPaths.push(path.join(gamesDir, file));
+            }
+        } catch {
+            // games dir absent in some test environments — skip silently
+        }
+
+        let loaded = 0;
+        await Promise.all(preloadPaths.map(async (p) => {
+            try {
+                const buf = await fs.promises.readFile(p);
+                this.bufferCache.set(p, buf);
+                loaded++;
+            } catch {
+                // Missing file → skip; getMediaBufferAsync will fall back to NotFound
+            }
+        }));
+        Logger.logInfo(`MediaService preloaded ${loaded} image(s) into buffer cache`);
+    }
+
+    /** @deprecated prefer getMediaBufferAsync — sync fs blocks the event loop. */
     public getMedia(image: Media): string {
         const imagePath = path.join(this.imagesPath, `${image.name}.${image.type}`);
 
@@ -39,19 +73,78 @@ class MediaService {
         return this.getMedia(image);
     }
 
+    public async getMediaAsync(image: Media): Promise<string> {
+        const imagePath = path.join(this.imagesPath, `${image.name}.${image.type}`);
+        if (await this.fileExistsAsync(imagePath))
+            return imagePath;
+        Logger.logInfo(`Image not found: ${image.name}.${image.type}, using NotFound.png`);
+        return this.notFoundImage.url;
+    }
+
+    /** @deprecated prefer getMediaBufferAsync. */
     public getMediaBuffer(image: Media): Buffer {
         const imagePath = this.getMedia(image);
         return fs.readFileSync(imagePath);
     }
 
+    /** @deprecated prefer getMediaBufferAsync. */
     public getMediaFromNameBuffer(name: string, type: MediaType): Buffer {
         const imagePath = this.getMediaFromName(name, type);
         return fs.readFileSync(imagePath);
     }
 
+    public async getMediaBufferAsync(image: Media): Promise<Buffer> {
+        const cachedByName = path.join(this.imagesPath, `${image.name}.${image.type}`);
+        const cachedByUrl = image.url;
+
+        const cached = this.bufferCache.get(cachedByUrl) ?? this.bufferCache.get(cachedByName);
+        if (cached)
+            return cached;
+
+        const targetPath = (await this.fileExistsAsync(image.url)) ? image.url : cachedByName;
+        try {
+            const buf = await fs.promises.readFile(targetPath);
+            this.bufferCache.set(targetPath, buf);
+            return buf;
+        } catch {
+            const fallback = this.bufferCache.get(this.notFoundImage.url);
+            if (fallback)
+                return fallback;
+            const buf = await fs.promises.readFile(this.notFoundImage.url);
+            this.bufferCache.set(this.notFoundImage.url, buf);
+            return buf;
+        }
+    }
+
+    public async getBufferByPathAsync(filePath: string): Promise<Buffer> {
+        const cached = this.bufferCache.get(filePath);
+        if (cached)
+            return cached;
+        const buf = await fs.promises.readFile(filePath);
+        this.bufferCache.set(filePath, buf);
+        return buf;
+    }
+
+    /** @deprecated prefer mediaExistsAsync. */
     public mediaExists(image: Media): boolean {
         const imagePath = path.join(this.imagesPath, `${image.name}.${image.type}`);
         return fs.existsSync(imagePath);
+    }
+
+    public async mediaExistsAsync(image: Media): Promise<boolean> {
+        const imagePath = path.join(this.imagesPath, `${image.name}.${image.type}`);
+        return this.fileExistsAsync(imagePath);
+    }
+
+    public async fileExistsAsync(filePath: string): Promise<boolean> {
+        if (this.bufferCache.has(filePath))
+            return true;
+        try {
+            await fs.promises.access(filePath);
+            return true;
+        } catch {
+            return false;
+        }
     }
 
     public getGameImage(gameName: GameTypeEnum): Media {
@@ -65,7 +158,7 @@ class MediaService {
             };
         }
 
-        Logger.logDebug(`Game image not found: ${gameImagePath}, using NotFound.png`);
+        Logger.logDebug(() => `Game image not found: ${gameImagePath}, using NotFound.png`);
         return this.notFoundImage;
     }
 
@@ -80,15 +173,66 @@ class MediaService {
             };
         }
 
-        Logger.logDebug(`Game image not found: ${gameImagePath}, using NotFound.png`);
+        Logger.logDebug(() => `Game image not found: ${gameImagePath}, using NotFound.png`);
         return this.notFoundImage;
     }
 
+    public async getGameImageBufferAsync(gameName: GameTypeEnum): Promise<Buffer> {
+        const media = this.getGameImage(gameName);
+        return this.getBufferByPathAsync(media.url);
+    }
+
+    /** @deprecated prefer getGameImageBufferAsync. */
     public getGameImageBuffer(gameName: GameTypeEnum): Buffer {
         const media = this.getGameImage(gameName);
         return fs.readFileSync(media.url);
     }
 
+    public async getMediaByGameIdAsync(gameId: number): Promise<GeneratedMedia[]> {
+        const gameDirectory = path.join(this.imagesPath, 'games', gameId.toString());
+
+        if (!(await this.fileExistsAsync(gameDirectory))) {
+            Logger.logInfo(`Game directory not found: ${gameDirectory}`);
+            return [];
+        }
+
+        try {
+            const files = await fs.promises.readdir(gameDirectory);
+            const mediaFiles: GeneratedMedia[] = [];
+
+            for (const file of files) {
+                if (file.endsWith('.png')) {
+                    const filePath = path.join(gameDirectory, file);
+                    const stats = await fs.promises.stat(filePath);
+
+                    const nameWithoutExt = file.replace('.png', '');
+                    const parts = nameWithoutExt.split('-');
+
+                    if (parts.length >= 2) {
+                        const serverId = parts[0];
+                        const uniqueCode = parts.slice(1).join('-');
+
+                        mediaFiles.push({
+                            id: uniqueCode,
+                            url: filePath,
+                            name: nameWithoutExt,
+                            type: MediaType.PNG,
+                            createdAt: stats.birthtime,
+                            gameId: gameId,
+                            serverId: serverId
+                        });
+                    }
+                }
+            }
+
+            return mediaFiles.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+        } catch (error) {
+            Logger.logError(`Error reading game directory ${gameDirectory}: ${error}`);
+            return [];
+        }
+    }
+
+    /** @deprecated prefer getMediaByGameIdAsync. */
     public getMediaByGameId(gameId: number): GeneratedMedia[] {
         const gameDirectory = path.join(this.imagesPath, 'games', gameId.toString());
 
@@ -144,9 +288,17 @@ class MediaService {
             };
         }
 
-        Logger.logDebug(`Base image not found: ${baseImagePath}, using NotFound.png`);
+        Logger.logDebug(() => `Base image not found: ${baseImagePath}, using NotFound.png`);
         return this.notFoundImage;
+    }
+
+    public _clearBufferCacheForTests(): void {
+        this.bufferCache.clear();
+    }
+
+    public _bufferCacheSizeForTests(): number {
+        return this.bufferCache.size;
     }
 }
 
-export default new MediaService(); 
+export default new MediaService();

--- a/src/services/discord/mappers/DiscordComponentMapper.ts
+++ b/src/services/discord/mappers/DiscordComponentMapper.ts
@@ -25,8 +25,8 @@ import DiscordEnumMapper from './DiscordEnumMapper';
 import { DiscordComponentBuilder, DiscordMessageContent, DiscordSelectMenuBuilder } from '../DiscordService';
 import ComponentService from '../../application/ComponentService';
 import { DEFAULT_EMBED_COLOR } from '../../../utils/constants/Colors';
-import * as fs from 'fs';
 import Logger from '../../../utils/application/Logger';
+import MediaService from '../../application/MediaService';
 import { withEventContextAsync } from '../../../middleware/EventContext';
 
 class DiscordComponentMapper {
@@ -406,7 +406,7 @@ class DiscordComponentMapper {
                 return null;
             }
 
-            const files: AttachmentBuilder[] = this.collectLocalAttachments(components);
+            const files: AttachmentBuilder[] = await this.collectLocalAttachmentsAsync(components);
 
             return this.createReplyOptions(rootComponents, files, ephemeral);
         });
@@ -421,47 +421,48 @@ class DiscordComponentMapper {
         };
     }
 
-    private collectLocalAttachments(components: Component[]): AttachmentBuilder[] {
-        const files: AttachmentBuilder[] = [];
+    private async collectLocalAttachmentsAsync(components: Component[]): Promise<AttachmentBuilder[]> {
+        const items: MediaGallery['items'][number][] = [];
 
-        const findMediaGalleries = (components: Component[]): void => {
+        const collect = (components: Component[]): void => {
             for (const component of components) {
                 if (!component || !component.type)
                     continue;
 
                 if (component.type === ComponentType.MEDIA_GALLERY) {
                     const mediaGallery = component as MediaGallery;
-
                     for (const item of mediaGallery.items) {
-                        if (!item.media.url.startsWith('http:') && !item.media.url.startsWith('https:')) {
-                            try {
-                                // Validate that file exists before trying to read it
-                                if (!fs.existsSync(item.media.url)) {
-                                    Logger.logWarning(`File not found: ${item.media.url}`);
-                                    continue;
-                                }
-
-                                // Read file as Buffer to prevent stream issues
-                                const fileBuffer = fs.readFileSync(item.media.url);
-                                Logger.logDebug(`Attachment loaded: ${item.media.name}.${item.media.type} (${fileBuffer.length} bytes)`);
-                                files.push(new AttachmentBuilder(fileBuffer, { name: `${item.media.name}.${item.media.type}` }));
-                            } catch (error) {
-                                Logger.logError(`Error loading file: ${item.media.url}`, error as Error);
-                                // Skip this file if it cannot be loaded
-                            }
-                        }
+                        if (!item.media.url.startsWith('http:') && !item.media.url.startsWith('https:'))
+                            items.push(item);
                     }
                 } else if (component.type === ComponentType.CONTAINER) {
                     const container = component as Container;
-                    if (container.components) {
-                        findMediaGalleries(container.components);
-                    }
+                    if (container.components)
+                        collect(container.components);
                 }
             }
         };
 
-        findMediaGalleries(components);
-        return files;
+        collect(components);
+
+        // Read all local files concurrently — each goes through MediaService's buffer cache
+        const loaded = await Promise.all(items.map(async (item) => {
+            try {
+                if (!(await MediaService.fileExistsAsync(item.media.url))) {
+                    Logger.logWarning(`File not found: ${item.media.url}`);
+                    return null;
+                }
+                const fileBuffer = await MediaService.getBufferByPathAsync(item.media.url);
+                if (Logger.isDebugEnabled())
+                    Logger.logDebug(() => `Attachment loaded: ${item.media.name}.${item.media.type} (${fileBuffer.length} bytes)`);
+                return new AttachmentBuilder(fileBuffer, { name: `${item.media.name}.${item.media.type}` });
+            } catch (error) {
+                Logger.logError(`Error loading file: ${item.media.url}`, error as Error);
+                return null;
+            }
+        }));
+
+        return loaded.filter((file): file is AttachmentBuilder => file !== null);
     }
 
     public mapContentComponents(interaction: InteractionEvent): string {

--- a/src/services/discord/mappers/DiscordComponentMapper.ts
+++ b/src/services/discord/mappers/DiscordComponentMapper.ts
@@ -453,8 +453,7 @@ class DiscordComponentMapper {
                     return null;
                 }
                 const fileBuffer = await MediaService.getBufferByPathAsync(item.media.url);
-                if (Logger.isDebugEnabled())
-                    Logger.logDebug(() => `Attachment loaded: ${item.media.name}.${item.media.type} (${fileBuffer.length} bytes)`);
+                Logger.logDebug(() => `Attachment loaded: ${item.media.name}.${item.media.type} (${fileBuffer.length} bytes)`);
                 return new AttachmentBuilder(fileBuffer, { name: `${item.media.name}.${item.media.type}` });
             } catch (error) {
                 Logger.logError(`Error loading file: ${item.media.url}`, error as Error);

--- a/src/services/image/GameImageService.ts
+++ b/src/services/image/GameImageService.ts
@@ -253,6 +253,7 @@ class GameImageService {
 
         // Write to file
         const buffer = canvas.toBuffer('image/png');
+        // TODO(feat-customization merge): switch to fs.promises.writeFile; ProfileCard.ts has the canonical async write pattern.
         fs.writeFileSync(filepath, buffer);
     }
 

--- a/src/utils/application/Logger.ts
+++ b/src/utils/application/Logger.ts
@@ -62,9 +62,15 @@ class Logger {
         await this.log(LogLevel.ERROR, message, error, options);
     }
 
-    public async logDebug(message: string, options?: LoggerOptions): Promise<void> {
-        if (TestMode.isDebugModeEnabled() || (!TestMode.isEnabled() && getConfigValue(EnvConfigEnum.DEBUG_MODE)))
-            await this.log(LogLevel.DEBUG, message, undefined, options);
+    public isDebugEnabled(): boolean {
+        return TestMode.isDebugModeEnabled() || (!TestMode.isEnabled() && !!getConfigValue(EnvConfigEnum.DEBUG_MODE));
+    }
+
+    public async logDebug(message: string | (() => string), options?: LoggerOptions): Promise<void> {
+        if (!this.isDebugEnabled())
+            return;
+        const resolved = typeof message === 'function' ? message() : message;
+        await this.log(LogLevel.DEBUG, resolved, undefined, options);
     }
 
     public async logTest(message: string): Promise<void> {

--- a/src/utils/registries/InitRegistry.ts
+++ b/src/utils/registries/InitRegistry.ts
@@ -1,8 +1,10 @@
 import GameService from "../../services/domain/GameService";
+import MediaService from "../../services/application/MediaService";
 import MetricService from "../../services/domain/MetricService";
 import UserService from "../../services/domain/UserService";
 
 export async function initAsync(): Promise<void> {
+    await MediaService.initAsync();
     await GameService.initAsync();
     await UserService.initAsync();
     await MetricService.initAsync();

--- a/tests/TestRunner.ts
+++ b/tests/TestRunner.ts
@@ -136,16 +136,21 @@ export class TestRunner {
                 await suite.beforeEach();
             }
 
-            // Start database transaction
-            await DatabaseTestHelper.startTestCaseAsync();
+            const invokeTest = async () => {
+                if (this.debugMode) {
+                    await test.testFunction();
+                } else {
+                    const timeout = test.timeout || this.config.testTimeout;
+                    await this.runWithTimeoutAsync(test.testFunction, timeout);
+                }
+            };
 
-            if (this.debugMode) {
-                // Run the actual test without timeout
-                await test.testFunction();
+            if (test.bypassTransaction) {
+                // Tests that exercise the pool/transaction layer itself must run outside
+                // the ambient test transaction, otherwise every query is pinned to one connection.
+                await invokeTest();
             } else {
-                // Run the actual test with timeout
-                const timeout = test.timeout || this.config.testTimeout;
-                await this.runWithTimeoutAsync(test.testFunction, timeout);
+                await DatabaseTestHelper.runTestCaseAsync(invokeTest);
             }
 
             const duration = Date.now() - startTime;
@@ -173,9 +178,6 @@ export class TestRunner {
 
         } finally {
             try {
-                // Rollback database transaction
-                await DatabaseTestHelper.endTestCaseAsync();
-
                 // Run afterEach
                 if (suite.afterEach) {
                     await suite.afterEach();

--- a/tests/config/TestDatabase.ts
+++ b/tests/config/TestDatabase.ts
@@ -2,12 +2,22 @@ import Logger from '../../src/utils/application/Logger';
 import { DatabaseHelper } from '../../src/utils/database/DatabaseHelper';
 import { BaseEntityFieldType } from '../../src/interfaces/database/BaseEntity';
 import { ExceptionEnum, TableEnum } from '../../src/interfaces/enums';
-import { closeConnectionAsync, commitTransactionAsync, getTableName, rollbackTransactionAsync, runQueryAsync, startTransactionAsync, validateConnectionAsync } from '../../src/repositories/util/ConnectionHandler';
+import {
+    closeConnectionAsync,
+    commitTransactionAsync,
+    getTableName,
+    rollbackTransactionAsync,
+    runInTransactionAsync,
+    runQueryAsync,
+    startTransactionAsync,
+    validateConnectionAsync,
+    TransactionHandle,
+} from '../../src/repositories/util/ConnectionHandler';
 import { ErrorHelper } from '../../src/utils/application/Error';
 
 export class TestDatabase {
     private static _instance: TestDatabase;
-    private _isInTransaction: boolean = false;
+    private _tx: TransactionHandle | null = null;
 
     private constructor() {}
 
@@ -18,46 +28,58 @@ export class TestDatabase {
         return TestDatabase._instance;
     }
 
-    public async startTransactionAsync(): Promise<void> {
-        if (this._isInTransaction)
+    public async startTransactionAsync(): Promise<TransactionHandle> {
+        if (this._tx)
             throw new Error('Transaction already started');
 
-        await startTransactionAsync();
-        this._isInTransaction = true;
+        this._tx = await startTransactionAsync();
         Logger.logDebug('Test transaction started');
+        return this._tx;
     }
 
     public async rollbackTransactionAsync(): Promise<void> {
-        if (!this.isInTransaction())
+        if (!this._tx)
             throw new Error('No active transaction to rollback');
 
-        await rollbackTransactionAsync();
-        this._isInTransaction = false;
+        const tx = this._tx;
+        this._tx = null;
+        await rollbackTransactionAsync(tx);
         Logger.logDebug('Test transaction rolled back');
     }
 
     public async commitTransactionAsync(): Promise<void> {
-        if (!this.isInTransaction())
+        if (!this._tx)
             throw new Error('No active transaction to commit');
 
-        await commitTransactionAsync();
-        this._isInTransaction = false;
+        const tx = this._tx;
+        this._tx = null;
+        await commitTransactionAsync(tx);
         Logger.logDebug('Test transaction committed');
+    }
+
+    /**
+     * Runs `body` with the active test transaction installed as the ambient handle, so any
+     * repository query inside picks it up automatically via AsyncLocalStorage.
+     */
+    public async withAmbientTransactionAsync<T>(body: () => Promise<T>): Promise<T> {
+        if (!this._tx)
+            throw new Error('No active transaction to bind ambient context to');
+        return runInTransactionAsync(this._tx, body);
     }
 
     public async runQueryAsync(query: string, params?: any[]): Promise<any[]> {
         await validateConnectionAsync();
 
         try {
-            Logger.logDebug(`Query: ${query}${params ? ` with params ${JSON.stringify(params)}` : ''}`);
-            const rows = await runQueryAsync(query, params);
-            
+            Logger.logDebug(() => `Query: ${query}${params ? ` with params ${JSON.stringify(params)}` : ''}`);
+            const rows = await runQueryAsync(query, params, this._tx ?? undefined);
+
             // For non-SELECT queries (INSERT, UPDATE, DELETE), return empty array
             const trimmedQuery = query.trim().toUpperCase();
             if (!trimmedQuery.startsWith('SELECT') && !trimmedQuery.startsWith('CALL')) {
                 return [];
             }
-            
+
             // Process results to handle MultiLingualString and JSON fields like BaseRepository
             return DatabaseHelper.processResultsFromDatabase(rows as any[]);
         } catch (error) {
@@ -74,9 +96,9 @@ export class TestDatabase {
         const values = Object.values(processedData).map(() => '?').join(', ');
         const query = `INSERT INTO ${tableNameString} (${keys}) VALUES (${values})`;
         const params = Object.values(processedData);
-        
+
         await this.runQueryAsync(query, params);
-        
+
         // Return the inserted record
         const selectQuery = `SELECT * FROM ${tableNameString} ORDER BY Id DESC LIMIT 1`;
         const result = await this.runQueryAsync(selectQuery);
@@ -96,7 +118,7 @@ export class TestDatabase {
         const params = [...Object.values(processedData).filter((_, index) => Object.keys(processedData)[index] !== 'Id'), id];
 
         await this.runQueryAsync(query, params);
-        
+
         // Return the updated record
         const selectQuery = `SELECT * FROM ${tableNameString} WHERE Id = ?`;
         const result = await this.runQueryAsync(selectQuery, [id]);
@@ -106,13 +128,13 @@ export class TestDatabase {
     public async callStoredProcedureAsync(procedureName: string, params: any[] = []): Promise<any[]> {
         const query = `CALL ${procedureName}(${params.map(() => '?').join(', ')})`;
         const results = await this.runQueryAsync(query, params);
-        
+
         // Process stored procedure results
         return DatabaseHelper.processStoredProcedureResults(results);
     }
 
     public isInTransaction(): boolean {
-        return this._isInTransaction;
+        return this._tx !== null;
     }
 
     public async closeAsync(): Promise<void> {

--- a/tests/fixtures/servers.ts
+++ b/tests/fixtures/servers.ts
@@ -9,19 +9,16 @@ export const TEST_SERVERS: ServersSaveModel[] = [
         ServerId: '987654321',
         Name: 'TestServer',
         LanguageEnum: LanguageEnum.NL,
-        Points: 0
     }),
     new ServersSaveModel({
         ServerId: '123456789',
         Name: 'TestServer',
         LanguageEnum: LanguageEnum.EN,
-        Points: 100
     }),
     new ServersSaveModel({
         ServerId: '555666777',
         Name: 'TestServer',
         LanguageEnum: LanguageEnum.NL,
-        Points: 50
     }),
 ];
 

--- a/tests/helpers/DatabaseTestHelper.ts
+++ b/tests/helpers/DatabaseTestHelper.ts
@@ -13,12 +13,17 @@ export class DatabaseTestHelper {
         this.enableTestMode();
     }
 
-    public static async startTestCaseAsync(): Promise<void> {
+    /**
+     * Wraps a test body in a per-test transaction with an ambient TransactionHandle.
+     * Any repository call inside picks up the handle automatically — no plumbing needed.
+     */
+    public static async runTestCaseAsync(body: () => Promise<void>): Promise<void> {
         await TestDatabase.startTransactionAsync();
-    }
-
-    public static async endTestCaseAsync(): Promise<void> {
-        await TestDatabase.rollbackTransactionAsync();
+        try {
+            await TestDatabase.withAmbientTransactionAsync(body);
+        } finally {
+            await TestDatabase.rollbackTransactionAsync();
+        }
     }
 
     public static async teardownAsync(): Promise<void> {
@@ -47,9 +52,9 @@ export class DatabaseTestHelper {
             const tableName = getTableName(tableEnum);
             try {
                 await TestDatabase.runQueryAsync(`DELETE FROM ${tableName} WHERE 1=1`);
-                Logger.logDebug(`Cleaned test data from table: ${tableName}`);
+                Logger.logDebug(() => `Cleaned test data from table: ${tableName}`);
             } catch (error) {
-                Logger.logDebug(`Could not clean table ${tableName}: ${(error as Error)?.message}`);
+                Logger.logDebug(() => `Could not clean table ${tableName}: ${(error as Error)?.message}`);
             }
         }
     }

--- a/tests/interfaces/TestRunnerInterface.ts
+++ b/tests/interfaces/TestRunnerInterface.ts
@@ -5,6 +5,12 @@ export interface TestCase {
     timeout?: number;
     skip?: boolean;
     only?: boolean;
+    /**
+     * If true, the test body runs OUTSIDE the per-test database transaction.
+     * Required for tests that exercise the pool/transaction layer itself, or that
+     * need parallel connections (the ambient transaction pins everything to one).
+     */
+    bypassTransaction?: boolean;
 }
 
 export interface TestSuite {

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "module": "CommonJS",
+    "module": "Node16",
     "target": "ES2020",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,

--- a/tests/unit/repositories/BaseRepository.test.ts
+++ b/tests/unit/repositories/BaseRepository.test.ts
@@ -1,0 +1,192 @@
+import TestRunner from '../../TestRunner';
+import { TestSuite } from '../../interfaces/TestRunnerInterface';
+import AssertionHelpers from '../../helpers/AssertionHelpers';
+import BaseRepository from '../../../src/repositories/BaseRepository';
+import {
+    UsersModel,
+    UsersModelFieldEnum,
+    UsersSaveModel,
+    getUsersFieldType,
+} from '../../../src/interfaces/database/TableInterfaces';
+import { TableEnum, UserRoleEnum } from '../../../src/interfaces/enums';
+import { getTableName } from '../../../src/repositories/util/ConnectionHandler';
+import TestDatabase from '../../config/TestDatabase';
+
+function makeFreshUserRepo() {
+    return new BaseRepository<UsersModel, UsersSaveModel, typeof UsersModelFieldEnum>(
+        TableEnum.USERS,
+        UsersModelFieldEnum,
+        getUsersFieldType,
+    );
+}
+
+async function insertTestUser(userId: string, username: string): Promise<number> {
+    const tableName = getTableName(TableEnum.USERS);
+    await TestDatabase.runQueryAsync(
+        `INSERT INTO ${tableName} (UserId, Username, UserRoleEnum, CreatedAt) VALUES (?, ?, ?, NOW())`,
+        [userId, username, UserRoleEnum.USER],
+    );
+    const idRows = await TestDatabase.runQueryAsync(
+        `SELECT Id FROM ${tableName} WHERE UserId = ? ORDER BY Id DESC LIMIT 1`,
+        [userId],
+    );
+    return (idRows![0] as { Id: number }).Id;
+}
+
+interface Spy {
+    executeCalls: number;
+    queryCalls: number;
+    restore: () => void;
+}
+
+function spyOnAmbientTx(): Spy {
+    const tx = (TestDatabase as any)._tx;
+    if (!tx)
+        throw new Error('No ambient transaction handle on TestDatabase');
+    const conn = tx.connection;
+    const origExecute = conn.execute.bind(conn);
+    const origQuery = conn.query.bind(conn);
+    const spy: Spy = {
+        executeCalls: 0,
+        queryCalls: 0,
+        restore: () => {
+            conn.execute = origExecute;
+            conn.query = origQuery;
+        },
+    };
+    conn.execute = ((...args: any[]) => { spy.executeCalls++; return origExecute(...args); }) as any;
+    conn.query = ((...args: any[]) => { spy.queryCalls++; return origQuery(...args); }) as any;
+    return spy;
+}
+
+export default function registerBaseRepositoryTests(runner: TestRunner): void {
+    const suite: TestSuite = {
+        name: 'BaseRepository',
+        description: 'Save() cache-merge, execute() routing, and INSERT round-trip',
+
+        tests: [
+            {
+                name: 'Save UPDATE with cache hit returns merged entity (skips SELECT round-trip)',
+                testFunction: async () => {
+                    const repo = makeFreshUserRepo();
+                    const id = await insertTestUser(`hot-${Date.now()}-${Math.random()}`, 'OriginalName');
+
+                    // Warm the cache by reading the row through the repo
+                    const before = await repo.getById(id);
+                    AssertionHelpers.assertNotNull(before, 'before snapshot exists');
+
+                    const spy = spyOnAmbientTx();
+                    let saved: UsersModel;
+                    try {
+                        saved = await repo.Save({ Id: id, Username: 'UpdatedName' });
+                    } finally {
+                        spy.restore();
+                    }
+
+                    AssertionHelpers.assertEqual(spy.executeCalls, 1, 'exactly one execute() call (the UPDATE)');
+                    AssertionHelpers.assertEqual(spy.queryCalls, 0, 'no query() call — cache hit avoided the SELECT round-trip');
+
+                    AssertionHelpers.assertEqual(saved.Username, 'UpdatedName', 'returned model carries the new value');
+                    AssertionHelpers.assertEqual(saved.UserId, before!.UserId, 'returned model preserves cached fields');
+                }
+            },
+
+            {
+                name: 'Save UPDATE with cold cache falls back to SELECT',
+                testFunction: async () => {
+                    const repo = makeFreshUserRepo();
+                    const id = await insertTestUser(`cold-${Date.now()}-${Math.random()}`, 'OriginalName');
+
+                    // Do NOT prime the cache — go straight to Save
+                    repo.clearCache();
+
+                    const spy = spyOnAmbientTx();
+                    let saved: UsersModel;
+                    try {
+                        saved = await repo.Save({ Id: id, Username: 'ColdCacheName' });
+                    } finally {
+                        spy.restore();
+                    }
+
+                    // UPDATE + the cold-fallback SELECT both go through execute()
+                    AssertionHelpers.assertEqual(spy.executeCalls, 2, 'two execute() calls (UPDATE + cold-fallback SELECT)');
+                    AssertionHelpers.assertEqual(spy.queryCalls, 0, 'no query() call (SELECT goes through execute())');
+                    AssertionHelpers.assertEqual(saved.Username, 'ColdCacheName', 'returned model has new value');
+                }
+            },
+
+            {
+                name: 'Save UPDATE with no fields to update still returns the row',
+                testFunction: async () => {
+                    const repo = makeFreshUserRepo();
+                    const id = await insertTestUser(`noop-${Date.now()}-${Math.random()}`, 'NoOp');
+
+                    const saved = await repo.Save({ Id: id });
+                    AssertionHelpers.assertEqual(saved.Id, id, 'returned model has same id');
+                    AssertionHelpers.assertEqual(saved.Username, 'NoOp', 'returned model has original value');
+                }
+            },
+
+            {
+                name: 'Save INSERT chains LAST_INSERT_ID and returns populated row',
+                testFunction: async () => {
+                    const repo = makeFreshUserRepo();
+                    const userId = `ins-${Date.now()}-${Math.random()}`;
+
+                    const created = await repo.Save({
+                        UserId: userId,
+                        Username: 'Inserted',
+                        UserRoleEnum: UserRoleEnum.USER,
+                    });
+
+                    AssertionHelpers.assertGreaterThan(created.Id, 0, 'Insert returned a positive Id');
+                    AssertionHelpers.assertEqual(created.UserId, userId, 'returned UserId matches');
+                    AssertionHelpers.assertEqual(created.Username, 'Inserted', 'returned Username matches');
+                }
+            },
+
+            {
+                name: 'Execute() routes a LIMIT-free SELECT through execute()',
+                testFunction: async () => {
+                    const repo = makeFreshUserRepo();
+                    const userId = `sel-${Date.now()}-${Math.random()}`;
+                    await insertTestUser(userId, 'ExecuteRouting');
+
+                    const spy = spyOnAmbientTx();
+                    try {
+                        // No .Limit() → query has no LIMIT ?, so prepared-statement path is used.
+                        const rows = await repo.Select().Where({ UserId: userId }).Execute();
+                        AssertionHelpers.assertEqual(rows.length, 1, 'select returns 1 row');
+                    } finally {
+                        spy.restore();
+                    }
+
+                    AssertionHelpers.assertGreaterThan(spy.executeCalls, 0, 'Select hit execute() at least once');
+                    AssertionHelpers.assertEqual(spy.queryCalls, 0, 'Select did not use query()');
+                }
+            },
+
+            {
+                name: 'Execute() with LIMIT auto-falls back to query() (older-MySQL safety)',
+                testFunction: async () => {
+                    const repo = makeFreshUserRepo();
+                    const userId = `lim-${Date.now()}-${Math.random()}`;
+                    await insertTestUser(userId, 'LimitFallback');
+
+                    const spy = spyOnAmbientTx();
+                    try {
+                        const rows = await repo.Select().Where({ UserId: userId }).Limit(1).Execute();
+                        AssertionHelpers.assertEqual(rows.length, 1, 'select returns 1 row');
+                    } finally {
+                        spy.restore();
+                    }
+
+                    // LIMIT ? must route to query() for compatibility with older MySQL prepared protocol
+                    AssertionHelpers.assertGreaterThan(spy.queryCalls, 0, 'LIMIT ? fell back to query()');
+                }
+            }
+        ]
+    };
+
+    runner.addSuite(suite);
+}

--- a/tests/unit/repositories/ConnectionHandler.test.ts
+++ b/tests/unit/repositories/ConnectionHandler.test.ts
@@ -8,13 +8,17 @@ import {
     rollbackTransactionAsync,
     commitTransactionAsync,
     runInTransactionAsync,
-    _getPoolForTests,
 } from '../../../src/repositories/util/ConnectionHandler';
 
-// These tests verify the pool actually pools (parallel queries), that transactions
-// are isolated per handle, and that connections are returned to the pool on commit/rollback.
-// They MUST run with bypassTransaction so the ambient test transaction does not pin every
-// query to a single connection.
+// All assertions use observable MySQL behavior (CONNECTION_ID()) rather than
+// wall-clock timing or mysql2 private internals, so the suite is stable in CI.
+// Tests must bypass the ambient test transaction — otherwise every query is
+// pinned to a single connection and pool behavior cannot be observed.
+
+async function getConnectionIdViaPool(): Promise<number> {
+    const rows = await runQueryAsync('SELECT CONNECTION_ID() AS cid') as Array<{ cid: number }>;
+    return rows[0].cid;
+}
 
 export default function registerConnectionHandlerTests(runner: TestRunner): void {
     const suite: TestSuite = {
@@ -23,41 +27,44 @@ export default function registerConnectionHandlerTests(runner: TestRunner): void
 
         tests: [
             {
-                name: 'runQueryAsync uses the pool — concurrent queries run in parallel',
+                name: 'runQueryAsync fans out concurrent queries across multiple pool connections',
                 bypassTransaction: true,
                 testFunction: async () => {
-                    const start = Date.now();
-                    await Promise.all([
-                        runQueryAsync('SELECT SLEEP(0.1) AS slept'),
-                        runQueryAsync('SELECT SLEEP(0.1) AS slept'),
-                        runQueryAsync('SELECT SLEEP(0.1) AS slept'),
-                        runQueryAsync('SELECT SLEEP(0.1) AS slept'),
-                        runQueryAsync('SELECT SLEEP(0.1) AS slept'),
+                    // If the pool is real (not a single held connection), 5 concurrent
+                    // CONNECTION_ID() calls return at least 2 distinct connection ids.
+                    // Each connection has a unique server-side id, so a Set with size > 1
+                    // proves the queries ran in parallel on different connections.
+                    const ids = await Promise.all([
+                        getConnectionIdViaPool(),
+                        getConnectionIdViaPool(),
+                        getConnectionIdViaPool(),
+                        getConnectionIdViaPool(),
+                        getConnectionIdViaPool(),
                     ]);
-                    const elapsed = Date.now() - start;
-                    AssertionHelpers.assertLessThan(
-                        elapsed,
-                        400,
-                        `5 parallel 100ms queries should complete under 400ms with a real pool (took ${elapsed}ms)`,
+                    const unique = new Set(ids);
+                    AssertionHelpers.assertGreaterThan(
+                        unique.size,
+                        1,
+                        `concurrent queries should run on >1 distinct pool connection (got ids=${ids.join(',')})`,
                     );
                 }
             },
 
             {
-                name: 'runExecuteAsync also pools concurrent prepared queries',
+                name: 'runExecuteAsync also fans out across multiple pool connections',
                 bypassTransaction: true,
                 testFunction: async () => {
-                    const start = Date.now();
-                    await Promise.all([
-                        runExecuteAsync('SELECT SLEEP(?) AS slept', [0.1]),
-                        runExecuteAsync('SELECT SLEEP(?) AS slept', [0.1]),
-                        runExecuteAsync('SELECT SLEEP(?) AS slept', [0.1]),
+                    const rowsList = await Promise.all([
+                        runExecuteAsync('SELECT CONNECTION_ID() AS cid'),
+                        runExecuteAsync('SELECT CONNECTION_ID() AS cid'),
+                        runExecuteAsync('SELECT CONNECTION_ID() AS cid'),
                     ]);
-                    const elapsed = Date.now() - start;
-                    AssertionHelpers.assertLessThan(
-                        elapsed,
-                        300,
-                        `3 parallel 100ms execute calls should complete under 300ms (took ${elapsed}ms)`,
+                    const ids = rowsList.map((rows) => (rows as Array<{ cid: number }>)[0].cid);
+                    const unique = new Set(ids);
+                    AssertionHelpers.assertGreaterThan(
+                        unique.size,
+                        1,
+                        `concurrent execute() should use >1 distinct connection (got ids=${ids.join(',')})`,
                     );
                 }
             },
@@ -66,8 +73,6 @@ export default function registerConnectionHandlerTests(runner: TestRunner): void
                 name: 'two concurrent transaction handles use different connections',
                 bypassTransaction: true,
                 testFunction: async () => {
-                    // CONNECTION_ID() is per-connection. Two distinct handles must report
-                    // different connection ids → proves we are not holding a single shared connection.
                     const a = await startTransactionAsync();
                     const b = await startTransactionAsync();
                     try {
@@ -82,63 +87,69 @@ export default function registerConnectionHandlerTests(runner: TestRunner): void
             },
 
             {
-                name: 'commitTransactionAsync releases the connection back to the pool',
+                name: 'commitTransactionAsync releases the connection so it can be reused',
                 bypassTransaction: true,
                 testFunction: async () => {
-                    const pool = _getPoolForTests();
-                    AssertionHelpers.assertNotNull(pool, 'pool exists');
-
-                    const before = (pool as any)._allConnections?.length ?? 0;
-
-                    const tx = await startTransactionAsync();
-                    await runQueryAsync('SELECT 1', undefined, tx);
-                    await commitTransactionAsync(tx);
-
-                    const after = (pool as any)._allConnections?.length ?? 0;
+                    // Lock the pool to one connection by acquiring + committing in series.
+                    // If commit released the connection, the next acquire reuses the same
+                    // server-side id. If it didn't, the next acquire opens a new connection
+                    // with a different id.
+                    const seen = new Set<number>();
+                    for (let i = 0; i < 5; i++) {
+                        const tx = await startTransactionAsync();
+                        const [row] = await runQueryAsync('SELECT CONNECTION_ID() AS cid', undefined, tx) as Array<{ cid: number }>;
+                        seen.add(row.cid);
+                        await commitTransactionAsync(tx);
+                    }
                     AssertionHelpers.assertTrue(
-                        after - before <= 1,
-                        `pool size after commit should not grow unbounded (before=${before}, after=${after})`,
+                        seen.size <= 5,
+                        `at most 5 distinct ids across 5 cycles, got ${seen.size} (ids=${[...seen].join(',')})`,
+                    );
+                    // Strong contract: the pool reuses connections, so we never see more than
+                    // a small bounded set even after 5 cycles — typically just 1.
+                    AssertionHelpers.assertLessThan(
+                        seen.size,
+                        4,
+                        `commit must release back to the pool — saw ${seen.size} distinct ids across 5 serial commits`,
                     );
                 }
             },
 
             {
-                name: 'rollbackTransactionAsync releases the connection back to the pool',
+                name: 'rollbackTransactionAsync releases the connection so it can be reused',
                 bypassTransaction: true,
                 testFunction: async () => {
-                    const pool = _getPoolForTests();
-                    AssertionHelpers.assertNotNull(pool, 'pool exists');
-
-                    const before = (pool as any)._allConnections?.length ?? 0;
-
-                    const tx = await startTransactionAsync();
-                    await runQueryAsync('SELECT 1', undefined, tx);
-                    await rollbackTransactionAsync(tx);
-
-                    const after = (pool as any)._allConnections?.length ?? 0;
-                    AssertionHelpers.assertTrue(
-                        after - before <= 1,
-                        `pool size after rollback should not grow unbounded (before=${before}, after=${after})`,
+                    const seen = new Set<number>();
+                    for (let i = 0; i < 5; i++) {
+                        const tx = await startTransactionAsync();
+                        const [row] = await runQueryAsync('SELECT CONNECTION_ID() AS cid', undefined, tx) as Array<{ cid: number }>;
+                        seen.add(row.cid);
+                        await rollbackTransactionAsync(tx);
+                    }
+                    AssertionHelpers.assertLessThan(
+                        seen.size,
+                        4,
+                        `rollback must release back to the pool — saw ${seen.size} distinct ids across 5 serial rollbacks`,
                     );
                 }
             },
 
             {
-                name: 'runInTransactionAsync makes runQueryAsync route to the ambient handle',
+                name: 'runInTransactionAsync routes implicit queries through the ambient handle',
                 bypassTransaction: true,
                 testFunction: async () => {
                     const tx = await startTransactionAsync();
                     try {
                         const [outsideRow] = await runQueryAsync('SELECT CONNECTION_ID() AS cid', undefined, tx) as Array<{ cid: number }>;
 
-                        const insideRow = await runInTransactionAsync(tx, async () => {
+                        const insideCid = await runInTransactionAsync(tx, async () => {
                             // No explicit tx → AsyncLocalStorage delivers the ambient handle
                             const rows = await runQueryAsync('SELECT CONNECTION_ID() AS cid') as Array<{ cid: number }>;
-                            return rows[0];
+                            return rows[0].cid;
                         });
 
                         AssertionHelpers.assertEqual(
-                            insideRow.cid,
+                            insideCid,
                             outsideRow.cid,
                             'ambient context routes implicit queries through the same handle connection',
                         );
@@ -149,27 +160,23 @@ export default function registerConnectionHandlerTests(runner: TestRunner): void
             },
 
             {
-                name: 'sequential transactions reuse pool connections (no growth)',
+                name: 'sequential commit cycles do not exhaust the pool',
                 bypassTransaction: true,
                 testFunction: async () => {
-                    // Open + commit 5 transactions in series and confirm the pool's connection
-                    // count does not grow unbounded — each commit's release returns the
-                    // connection so the next acquisition reuses it.
-                    const pool = _getPoolForTests();
-                    AssertionHelpers.assertNotNull(pool, 'pool exists');
-
-                    const baselineSize = (pool as any)._allConnections?.length ?? 0;
-
-                    for (let i = 0; i < 5; i++) {
+                    // Open + commit 10 transactions in series. Each commit must release so the
+                    // pool can hand the connection back out — proving by the fact that the
+                    // distinct-ids set never explodes (would be 10 distinct ids without reuse).
+                    const seen = new Set<number>();
+                    for (let i = 0; i < 10; i++) {
                         const tx = await startTransactionAsync();
-                        await runQueryAsync('SELECT 1', undefined, tx);
+                        const [row] = await runQueryAsync('SELECT CONNECTION_ID() AS cid', undefined, tx) as Array<{ cid: number }>;
+                        seen.add(row.cid);
                         await commitTransactionAsync(tx);
                     }
-
-                    const finalSize = (pool as any)._allConnections?.length ?? 0;
-                    AssertionHelpers.assertTrue(
-                        finalSize - baselineSize <= 1,
-                        `pool size grew by at most 1 over 5 tx cycles (baseline=${baselineSize}, final=${finalSize})`,
+                    AssertionHelpers.assertLessThan(
+                        seen.size,
+                        5,
+                        `pool must reuse connections — got ${seen.size} distinct ids across 10 serial cycles`,
                     );
                 }
             }

--- a/tests/unit/repositories/ConnectionHandler.test.ts
+++ b/tests/unit/repositories/ConnectionHandler.test.ts
@@ -1,0 +1,180 @@
+import TestRunner from '../../TestRunner';
+import { TestSuite } from '../../interfaces/TestRunnerInterface';
+import AssertionHelpers from '../../helpers/AssertionHelpers';
+import {
+    runQueryAsync,
+    runExecuteAsync,
+    startTransactionAsync,
+    rollbackTransactionAsync,
+    commitTransactionAsync,
+    runInTransactionAsync,
+    _getPoolForTests,
+} from '../../../src/repositories/util/ConnectionHandler';
+
+// These tests verify the pool actually pools (parallel queries), that transactions
+// are isolated per handle, and that connections are returned to the pool on commit/rollback.
+// They MUST run with bypassTransaction so the ambient test transaction does not pin every
+// query to a single connection.
+
+export default function registerConnectionHandlerTests(runner: TestRunner): void {
+    const suite: TestSuite = {
+        name: 'ConnectionHandler',
+        description: 'Pool-backed query execution and per-handle transaction isolation',
+
+        tests: [
+            {
+                name: 'runQueryAsync uses the pool — concurrent queries run in parallel',
+                bypassTransaction: true,
+                testFunction: async () => {
+                    const start = Date.now();
+                    await Promise.all([
+                        runQueryAsync('SELECT SLEEP(0.1) AS slept'),
+                        runQueryAsync('SELECT SLEEP(0.1) AS slept'),
+                        runQueryAsync('SELECT SLEEP(0.1) AS slept'),
+                        runQueryAsync('SELECT SLEEP(0.1) AS slept'),
+                        runQueryAsync('SELECT SLEEP(0.1) AS slept'),
+                    ]);
+                    const elapsed = Date.now() - start;
+                    AssertionHelpers.assertLessThan(
+                        elapsed,
+                        400,
+                        `5 parallel 100ms queries should complete under 400ms with a real pool (took ${elapsed}ms)`,
+                    );
+                }
+            },
+
+            {
+                name: 'runExecuteAsync also pools concurrent prepared queries',
+                bypassTransaction: true,
+                testFunction: async () => {
+                    const start = Date.now();
+                    await Promise.all([
+                        runExecuteAsync('SELECT SLEEP(?) AS slept', [0.1]),
+                        runExecuteAsync('SELECT SLEEP(?) AS slept', [0.1]),
+                        runExecuteAsync('SELECT SLEEP(?) AS slept', [0.1]),
+                    ]);
+                    const elapsed = Date.now() - start;
+                    AssertionHelpers.assertLessThan(
+                        elapsed,
+                        300,
+                        `3 parallel 100ms execute calls should complete under 300ms (took ${elapsed}ms)`,
+                    );
+                }
+            },
+
+            {
+                name: 'two concurrent transaction handles use different connections',
+                bypassTransaction: true,
+                testFunction: async () => {
+                    // CONNECTION_ID() is per-connection. Two distinct handles must report
+                    // different connection ids → proves we are not holding a single shared connection.
+                    const a = await startTransactionAsync();
+                    const b = await startTransactionAsync();
+                    try {
+                        const [idA] = await runQueryAsync('SELECT CONNECTION_ID() AS cid', undefined, a) as Array<{ cid: number }>;
+                        const [idB] = await runQueryAsync('SELECT CONNECTION_ID() AS cid', undefined, b) as Array<{ cid: number }>;
+                        AssertionHelpers.assertNotEqual(idA.cid, idB.cid, 'each handle should bind a distinct pool connection');
+                    } finally {
+                        await rollbackTransactionAsync(a);
+                        await rollbackTransactionAsync(b);
+                    }
+                }
+            },
+
+            {
+                name: 'commitTransactionAsync releases the connection back to the pool',
+                bypassTransaction: true,
+                testFunction: async () => {
+                    const pool = _getPoolForTests();
+                    AssertionHelpers.assertNotNull(pool, 'pool exists');
+
+                    const before = (pool as any)._allConnections?.length ?? 0;
+
+                    const tx = await startTransactionAsync();
+                    await runQueryAsync('SELECT 1', undefined, tx);
+                    await commitTransactionAsync(tx);
+
+                    const after = (pool as any)._allConnections?.length ?? 0;
+                    AssertionHelpers.assertTrue(
+                        after - before <= 1,
+                        `pool size after commit should not grow unbounded (before=${before}, after=${after})`,
+                    );
+                }
+            },
+
+            {
+                name: 'rollbackTransactionAsync releases the connection back to the pool',
+                bypassTransaction: true,
+                testFunction: async () => {
+                    const pool = _getPoolForTests();
+                    AssertionHelpers.assertNotNull(pool, 'pool exists');
+
+                    const before = (pool as any)._allConnections?.length ?? 0;
+
+                    const tx = await startTransactionAsync();
+                    await runQueryAsync('SELECT 1', undefined, tx);
+                    await rollbackTransactionAsync(tx);
+
+                    const after = (pool as any)._allConnections?.length ?? 0;
+                    AssertionHelpers.assertTrue(
+                        after - before <= 1,
+                        `pool size after rollback should not grow unbounded (before=${before}, after=${after})`,
+                    );
+                }
+            },
+
+            {
+                name: 'runInTransactionAsync makes runQueryAsync route to the ambient handle',
+                bypassTransaction: true,
+                testFunction: async () => {
+                    const tx = await startTransactionAsync();
+                    try {
+                        const [outsideRow] = await runQueryAsync('SELECT CONNECTION_ID() AS cid', undefined, tx) as Array<{ cid: number }>;
+
+                        const insideRow = await runInTransactionAsync(tx, async () => {
+                            // No explicit tx → AsyncLocalStorage delivers the ambient handle
+                            const rows = await runQueryAsync('SELECT CONNECTION_ID() AS cid') as Array<{ cid: number }>;
+                            return rows[0];
+                        });
+
+                        AssertionHelpers.assertEqual(
+                            insideRow.cid,
+                            outsideRow.cid,
+                            'ambient context routes implicit queries through the same handle connection',
+                        );
+                    } finally {
+                        await rollbackTransactionAsync(tx);
+                    }
+                }
+            },
+
+            {
+                name: 'sequential transactions reuse pool connections (no growth)',
+                bypassTransaction: true,
+                testFunction: async () => {
+                    // Open + commit 5 transactions in series and confirm the pool's connection
+                    // count does not grow unbounded — each commit's release returns the
+                    // connection so the next acquisition reuses it.
+                    const pool = _getPoolForTests();
+                    AssertionHelpers.assertNotNull(pool, 'pool exists');
+
+                    const baselineSize = (pool as any)._allConnections?.length ?? 0;
+
+                    for (let i = 0; i < 5; i++) {
+                        const tx = await startTransactionAsync();
+                        await runQueryAsync('SELECT 1', undefined, tx);
+                        await commitTransactionAsync(tx);
+                    }
+
+                    const finalSize = (pool as any)._allConnections?.length ?? 0;
+                    AssertionHelpers.assertTrue(
+                        finalSize - baselineSize <= 1,
+                        `pool size grew by at most 1 over 5 tx cycles (baseline=${baselineSize}, final=${finalSize})`,
+                    );
+                }
+            }
+        ]
+    };
+
+    runner.addSuite(suite);
+}

--- a/tests/unit/services/MediaService.test.ts
+++ b/tests/unit/services/MediaService.test.ts
@@ -1,19 +1,17 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import TestRunner from '../../TestRunner';
 import { TestSuite } from '../../interfaces/TestRunnerInterface';
 import GameService from '../../../src/services/domain/GameService';
 import GameDataRepository from '../../../src/repositories/GameDataRepository';
 import MediaService from '../../../src/services/application/MediaService';
+import { MediaType } from '../../../src/interfaces/application/Media';
 import AssertionHelpers from '../../helpers/AssertionHelpers';
 
 export default function registerMediaServiceTests(runner: TestRunner): void {
     const suite: TestSuite = {
         name: 'MediaService',
         description: 'Unit tests for MediaService functionality',
-
-        setup: async () => {},
-        teardown: async () => {},
-        beforeEach: async () => {},
-        afterEach: async () => {},
 
         tests: [
             {
@@ -48,6 +46,108 @@ export default function registerMediaServiceTests(runner: TestRunner): void {
                         // Assert — result must not be the NotFound fallback
                         AssertionHelpers.assertNotNull(result, 'getGameDataImage should return a Media object');
                         AssertionHelpers.assertNotEqual(result.name, 'NotFound', `Image for game ${gameId} / data ${gameDataId} should exist`);
+                    }
+                }
+            },
+
+            {
+                name: 'getMediaBufferAsync hits cache on second call',
+                testFunction: async () => {
+                    MediaService._clearBufferCacheForTests();
+
+                    const image = { url: '', name: 'profile', type: MediaType.PNG };
+                    const expectedPath = path.join(process.cwd(), 'images', `profile.${MediaType.PNG}`);
+
+                    // First call → reads from disk and caches
+                    const first = await MediaService.getMediaBufferAsync(image);
+                    AssertionHelpers.assertNotNull(first, 'first read returned a buffer');
+                    AssertionHelpers.assertGreaterThan(first.length, 0, 'buffer non-empty');
+
+                    // Spy on fs.promises.readFile after the first read populated the cache
+                    const original = fs.promises.readFile;
+                    let readFileCalls = 0;
+                    (fs.promises as any).readFile = ((...args: any[]) => {
+                        readFileCalls++;
+                        return (original as any).apply(fs.promises, args);
+                    }) as typeof fs.promises.readFile;
+
+                    try {
+                        const second = await MediaService.getMediaBufferAsync(image);
+                        AssertionHelpers.assertEqual(second.length, first.length, 'same buffer length on cache hit');
+                        AssertionHelpers.assertEqual(readFileCalls, 0, 'cache hit must not call fs.promises.readFile');
+                        AssertionHelpers.assertTrue(expectedPath.length > 0, 'expected path resolved');
+                    } finally {
+                        (fs.promises as any).readFile = original;
+                    }
+                }
+            },
+
+            {
+                name: 'initAsync preloads base images so subsequent reads skip disk',
+                testFunction: async () => {
+                    MediaService._clearBufferCacheForTests();
+                    await MediaService.initAsync();
+
+                    const original = fs.promises.readFile;
+                    let readFileCalls = 0;
+                    (fs.promises as any).readFile = ((...args: any[]) => {
+                        readFileCalls++;
+                        return (original as any).apply(fs.promises, args);
+                    }) as typeof fs.promises.readFile;
+
+                    try {
+                        for (const name of ['welcome', 'profile', 'aboutme', 'settings'] as const) {
+                            const img = { url: '', name, type: MediaType.PNG };
+                            const buf = await MediaService.getMediaBufferAsync(img);
+                            AssertionHelpers.assertGreaterThan(buf.length, 0, `${name} buffer non-empty`);
+                        }
+                        AssertionHelpers.assertEqual(readFileCalls, 0, 'preloaded base images should not re-read from disk');
+                    } finally {
+                        (fs.promises as any).readFile = original;
+                    }
+                }
+            },
+
+            {
+                name: 'getMediaBufferAsync falls back to NotFound when image missing',
+                testFunction: async () => {
+                    MediaService._clearBufferCacheForTests();
+                    await MediaService.initAsync(); // populate NotFound in cache
+
+                    const missing = { url: '', name: 'definitely-not-a-real-image-xyz', type: MediaType.PNG };
+                    const buf = await MediaService.getMediaBufferAsync(missing);
+
+                    AssertionHelpers.assertNotNull(buf, 'fallback buffer returned');
+                    AssertionHelpers.assertGreaterThan(buf.length, 0, 'fallback buffer non-empty');
+
+                    // It should match the NotFound buffer specifically
+                    const notFoundBuf = await MediaService.getBufferByPathAsync(
+                        path.join(process.cwd(), 'images', `NotFound.${MediaType.PNG}`),
+                    );
+                    AssertionHelpers.assertEqual(buf.length, notFoundBuf.length, 'fallback buffer matches NotFound size');
+                }
+            },
+
+            {
+                name: 'fileExistsAsync uses cache hit as fast positive answer',
+                testFunction: async () => {
+                    MediaService._clearBufferCacheForTests();
+                    await MediaService.initAsync();
+
+                    const original = fs.promises.access;
+                    let accessCalls = 0;
+                    (fs.promises as any).access = ((...args: any[]) => {
+                        accessCalls++;
+                        return (original as any).apply(fs.promises, args);
+                    }) as typeof fs.promises.access;
+
+                    try {
+                        const cachedPath = path.join(process.cwd(), 'images', `profile.${MediaType.PNG}`);
+                        const exists = await MediaService.fileExistsAsync(cachedPath);
+                        AssertionHelpers.assertTrue(exists, 'cached path reports exists');
+                        AssertionHelpers.assertEqual(accessCalls, 0, 'cached existence check skips fs.access');
+                    } finally {
+                        (fs.promises as any).access = original;
                     }
                 }
             }

--- a/tests/unit/services/MediaService.test.ts
+++ b/tests/unit/services/MediaService.test.ts
@@ -75,7 +75,14 @@ export default function registerMediaServiceTests(runner: TestRunner): void {
                         const second = await MediaService.getMediaBufferAsync(image);
                         AssertionHelpers.assertEqual(second.length, first.length, 'same buffer length on cache hit');
                         AssertionHelpers.assertEqual(readFileCalls, 0, 'cache hit must not call fs.promises.readFile');
-                        AssertionHelpers.assertTrue(expectedPath.length > 0, 'expected path resolved');
+                        // Validates that the cached entry is keyed by the expected resolved path
+                        const fromPath = await MediaService.getBufferByPathAsync(expectedPath);
+                        AssertionHelpers.assertEqual(
+                            fromPath.length,
+                            first.length,
+                            'getBufferByPathAsync returns the same cached buffer for the resolved path',
+                        );
+                        AssertionHelpers.assertEqual(readFileCalls, 0, 'path-based cache lookup also skipped fs.readFile');
                     } finally {
                         (fs.promises as any).readFile = original;
                     }

--- a/tests/unit/utils/Logger.test.ts
+++ b/tests/unit/utils/Logger.test.ts
@@ -1,0 +1,79 @@
+import TestRunner from '../../TestRunner';
+import { TestSuite } from '../../interfaces/TestRunnerInterface';
+import Logger from '../../../src/utils/application/Logger';
+import TestMode from '../../../src/utils/application/TestMode';
+import AssertionHelpers from '../../helpers/AssertionHelpers';
+
+export default function registerLoggerTests(runner: TestRunner): void {
+    const suite: TestSuite = {
+        name: 'Logger',
+        description: 'Unit tests for debug-mode gating and thunk interpolation',
+
+        tests: [
+            {
+                name: 'logDebug skips thunk interpolation when debug is off',
+                testFunction: async () => {
+                    const debugWasOn = TestMode.isDebugModeEnabled();
+                    if (debugWasOn) TestMode.disableDebugMode();
+
+                    try {
+                        let calls = 0;
+                        await Logger.logDebug(() => { calls++; return 'should-not-build'; });
+                        AssertionHelpers.assertEqual(calls, 0, 'thunk must not be invoked when debug is off');
+                    } finally {
+                        if (debugWasOn) TestMode.enableDebugMode();
+                    }
+                }
+            },
+
+            {
+                name: 'logDebug invokes thunk exactly once when debug is on',
+                testFunction: async () => {
+                    const debugWasOn = TestMode.isDebugModeEnabled();
+                    TestMode.enableDebugMode();
+                    try {
+                        let calls = 0;
+                        await Logger.logDebug(() => { calls++; return 'built'; });
+                        AssertionHelpers.assertEqual(calls, 1, 'thunk runs once when debug is on');
+                    } finally {
+                        if (!debugWasOn) TestMode.disableDebugMode();
+                    }
+                }
+            },
+
+            {
+                name: 'logDebug accepts plain strings as before',
+                testFunction: async () => {
+                    const debugWasOn = TestMode.isDebugModeEnabled();
+                    TestMode.enableDebugMode();
+                    try {
+                        // No-throw is the contract: existing call sites stay compatible
+                        await Logger.logDebug('plain string still works');
+                        AssertionHelpers.assertTrue(true, 'string overload did not throw');
+                    } finally {
+                        if (!debugWasOn) TestMode.disableDebugMode();
+                    }
+                }
+            },
+
+            {
+                name: 'isDebugEnabled reflects TestMode debug flag',
+                testFunction: async () => {
+                    const debugWasOn = TestMode.isDebugModeEnabled();
+
+                    TestMode.enableDebugMode();
+                    AssertionHelpers.assertTrue(Logger.isDebugEnabled(), 'should be true when TestMode debug is on');
+
+                    TestMode.disableDebugMode();
+                    // With TestMode enabled (test runner enabled it on boot), isDebugEnabled
+                    // ignores DEBUG_MODE env. So disabling TestMode debug must report false.
+                    AssertionHelpers.assertFalse(Logger.isDebugEnabled(), 'should be false when TestMode debug is off');
+
+                    if (debugWasOn) TestMode.enableDebugMode();
+                }
+            }
+        ]
+    };
+
+    runner.addSuite(suite);
+}


### PR DESCRIPTION
> Replaces global connection state with per-transaction context, improves query execution robustness, and optimises startup parallelism.

### Changes
- Replaced global `connection`/`inTransaction` state in `ConnectionHandler` with `AsyncLocalStorage`-based per-transaction context via `TransactionHandle` and `runInTransactionAsync`
- Replaced `runQueryAsync` with `runExecuteAsync`, routing all queries through `runWithRetry` for connection loss recovery and correct transaction-aware connection selection
- Updated all repository code to use `runExecuteAsync`
- `BaseRepository` cache update now merges known new values directly instead of re-fetching; cache invalidation corrected for hot and cold paths
- Startup parallelised: DB sync and schema validation now run concurrently; command and event loading likewise
- Discord login skipped in test mode via `TestMode.isEnabled()` to prevent race conditions